### PR TITLE
Multiplayer Support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import datetime
+import json
 import os
 import sys
 from hashlib import sha1
@@ -52,7 +53,7 @@ r.set("room_id", room_id)
 
 executor = concurrent.futures.ThreadPoolExecutor(max_workers=20)
 
-cred = credentials.Certificate(os.environ["FIREBASE_AUTH"])
+cred = credentials.Certificate(json.loads(os.environ["FIREBASE_AUTH"]))
 initialize_app(cred, {"databaseURL": os.environ["FIREBASE_URL"]})
 ref = db.reference("/")
 


### PR DESCRIPTION
## Description

Adds support for multiple players in the ASIST game. Each player will be able to join a game with other players, see real time updates on other players' movements, as well as victim rescues.

### Changes
- Updated player limit from 1 to 2 (arbitrary, can change)
- Removed `eval` wrapper from `os.environ["FIREBASE_AUTH"]` and replaced it with safer option `json.loads`
- Refactored `rescue_success` handler to split into `rescue` and `rescue_displayed` handler
    - New flow:
        - Client emits "rescue_attempt" event (this happens independent of the following events)
        - Client emits "rescue" event
        - Server emits "rescue_success" event
        - Client emits "rescue_displayed" event
    - Note: followed the same pattern for socket communication as player movements

Related frontend changes: https://github.com/anitejb/ASIST-Client/tree/feature/multiplayer 